### PR TITLE
sass-output-region() and sass-output-buffer()

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -181,9 +181,17 @@ LIMIT is the limit of the search."
 
 ;; Mode setup
 
+(defvar sass-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\C-c\C-r" 'sass-output-region)
+    (define-key map "\C-c\C-l" 'sass-output-buffer)
+    map))
+
 ;;;###autoload
 (define-derived-mode sass-mode haml-mode "Sass"
-  "Major mode for editing Sass files."
+  "Major mode for editing Sass files.
+
+\\{sass-mode-map}"
   (set-syntax-table sass-syntax-table)
   (setq font-lock-extend-region-functions
         '(font-lock-extend-region-wholelines font-lock-extend-region-multiline))
@@ -200,6 +208,24 @@ LIMIT is the limit of the search."
   (loop for opener in sass-non-block-openers
         if (looking-at opener) return nil
         finally return t))
+
+;; Command
+
+(defun sass-output-region (start end)
+  "Displays the CSS output for the current block of Sass code.
+Called from a program, START and END specify the region to indent."
+  (interactive "r")
+  (let* ((text (buffer-substring-no-properties start end))
+         (command (format "ruby -rubygems -e \"require 'sass'; puts Sass::Engine.new('%s').render\"" text)))
+  (kill-new text)
+  (with-temp-buffer
+    (yank)
+    (shell-command-on-region (point-min) (point-max) command "sass-output"))))
+
+(defun sass-output-buffer ()
+  "Displays the CSS output for entire buffer."
+  (interactive)
+  (sass-output-region (point-min) (point-max)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.sass$" . sass-mode))


### PR DESCRIPTION
I added two commands, sass-output-region() and sass-output-buffer().
These commands looks like haml-output-region() and haml-output-buffer() in haml-mode.el.
And These commands useful, when confirm css output.
