### PR TITLE
auto-mode-alisp pattern should ends with \\

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -202,7 +202,7 @@ LIMIT is the limit of the search."
         finally return t))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.sass\\" . sass-mode))
+(add-to-list 'auto-mode-alist '("\\.sass\\'" . sass-mode))
 
 ;; Setup/Activation
 (provide 'sass-mode)


### PR DESCRIPTION
Hello I'm the maintainer of the sass-mode package for debian and I received this bug: 
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=712279

Doing a little of research  I found that \ is better than $ to used as ends of a line pattern, see this:

for string ends see: http://www.emacswiki.org/emacs/AutoModeAlist

Thanks
