### PR TITLE
Make comments toggleable with M-;

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -198,6 +198,7 @@ LIMIT is the limit of the search."
         '(font-lock-extend-region-wholelines font-lock-extend-region-multiline))
   (set (make-local-variable 'font-lock-multiline) nil)
   (set (make-local-variable 'comment-start) "/*")
+  (set (make-local-variable 'comment-start-skip) "/[/*]\s*")
   (set (make-local-variable 'haml-indent-function) 'sass-indent-p)
   (set (make-local-variable 'haml-indent-offset) sass-indent-offset)
   (setq font-lock-defaults '(sass-font-lock-keywords t t)))


### PR DESCRIPTION
Huzzah, now we can use `(comment-or-uncomment-region)`  to _toggle_ our comments in sass-mode
