### PR TITLE
Fixed can't recognize "subexp-or-fn" bug.

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -25,6 +25,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl-lib))
+
 (require 'haml-mode)
 
 ;; User definable variables


### PR DESCRIPTION
This bug happends randomly on emacs 24.4.
