### PR TITLE
Adding pre-eval hook function and sass-command-options

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -45,6 +45,11 @@
   :type 'integer
   :group 'sass)
 
+(defcustom sass-command-options nil
+  "Options to pass to the `sass' command."
+  :type 'string
+  :group 'sass)
+
 (defvar sass-non-block-openers
   '("^.*,$" ;; Continued selectors
     "^ *@\\(extend\\|debug\\|warn\\|include\\|import\\)" ;; Single-line mixins
@@ -237,7 +242,7 @@ Called from a program, START and END specify the region to indent."
              (insert region-contents)
              (newline-and-indent)
              (sass--remove-leading-indent)
-             (shell-command-on-region (point-min) (point-max) "sass --stdin"
+             (shell-command-on-region (point-min) (point-max) (mapconcat #'identity (list "sass" sass-command-options "--stdin") " ")
                                       output-buffer
                                       nil
                                       errors-buffer

--- a/sass-mode.el
+++ b/sass-mode.el
@@ -50,6 +50,11 @@
   :type 'string
   :group 'sass)
 
+(defcustom sass-before-eval-hook nil
+  "Hook run in the buffer used as input to the `sass' command."
+  :type 'hook
+  :group 'sass)
+
 (defvar sass-non-block-openers
   '("^.*,$" ;; Continued selectors
     "^ *@\\(extend\\|debug\\|warn\\|include\\|import\\)" ;; Single-line mixins
@@ -241,6 +246,7 @@ Called from a program, START and END specify the region to indent."
            (with-temp-buffer
              (insert region-contents)
              (newline-and-indent)
+             (run-hooks 'sass-before-eval-hook)
              (sass--remove-leading-indent)
              (shell-command-on-region (point-min) (point-max) (mapconcat #'identity (list "sass" sass-command-options "--stdin") " ")
                                       output-buffer


### PR DESCRIPTION
This commit adds a conditional call to `sass-prepare-input-buffer` if it
is defined, enabling the user to extend the code being evaluated by
`sass-output-region` the way he sees fit.

It also introduces the `sass-command-options` option, for customizing
the `sass` command line options.

--

This was motivated by my need to call some custom imports when I want to verify a `sass` output. So, my `sass-prepare-input-buffer` looks something like this:

```elisp
(defun sass-prepare-input-buffer ()
  "Inserts common imports into the temporary buffer with the code to be evaluated."
  (goto-char (point-min))
  (if (inside-importable-project)
      (insert-file-contents "~/dotfiles/pre-eval-code.sass")))
```

Please let me know if this code is interesting, or if there's a better way to do it through `sass` alone.