### PR TITLE
Fix package version and upstream URL

### DIFF
--- a/sass-mode.el
+++ b/sass-mode.el
@@ -3,8 +3,8 @@
 ;; Copyright (c) 2007, 2008 Natalie Weizenbaum
 
 ;; Author: Natalie Weizenbaum
-;; URL: http://github.com/nex3/haml/tree/master
-;; Version: 3.0.16
+;; URL: https://github.com/nex3/sass-mode
+;; Version: 3.0.19
 ;; Created: 2007-03-15
 ;; By: Natalie Weizenbaum
 ;; Keywords: markup, language, css


### PR DESCRIPTION
This will allow to update package and its info on nongnu repository

This is my answer to my comment on issue #10 some minutes ago. Here I propose to name this new version 3.0.19, but feel free to change it if you want. You’ll need to tag the new release after.

Thank you very much.